### PR TITLE
Update jQuery to latest version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 
 {% seo %}
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.0.min.js" integrity="sha256-RTQy8VOmNlT6b2PIRur37p6JEBZUE7o8wPgMvu18MC4=" crossorigin="anonymous"></script>
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <!--[if lt IE 9]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,7 +12,7 @@ var sectionHeight = function() {
 
 $(window).resize(sectionHeight);
 
-$(document).ready(function(){
+$(function() {
   $("section h1, section h2").each(function(){
     $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'') + "'>" + $(this).text() + "</a></li>");
     $(this).attr("id",$(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,''));
@@ -29,7 +29,7 @@ $(document).ready(function(){
 
   sectionHeight();
 
-  $('img').load(sectionHeight);
+  $('img').on('load', sectionHeight);
 });
 
 fixScale = function(doc) {


### PR DESCRIPTION
This updates jQuery to the latest version.

The [``ready()`` method](https://api.jquery.com/ready/) syntax has been updated:
> As of jQuery 3.0, only the first syntax is recommended; the other syntaxes still work but are deprecated.

[``load()`` event handler shortcut method](https://api.jquery.com/load-event/) has been replaced as it was deprecated in jQuery v1.8 and is now removed.