### PR TITLE
Scroll to heading specified in URL

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -26,6 +26,14 @@ $(function() {
     $(this).parent().addClass("active");
     event.preventDefault();
   });
+  
+  // Scroll to requested header if specified in URL.
+  var url = window.location.href;
+  var inx = url.indexOf("#");
+  if (inx !== -1) {
+    var hash = url.substring(inx + 1);
+    $("a[href='#" + hash + "']").click();
+  }
 
   sectionHeight();
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,6 +10,16 @@ var sectionHeight = function() {
   }
 }
 
+var scrollToHeadingInUrl = function() {
+  var url = window.location.href,
+      inx = url.indexOf("#");
+  
+  if (inx !== -1) {
+    var hash = url.substring(inx + 1);
+    $("a[href='#" + hash + "']").click();
+  }
+}
+
 $(window).resize(sectionHeight);
 
 $(function() {
@@ -27,15 +37,9 @@ $(function() {
     event.preventDefault();
   });
   
-  // Scroll to requested header if specified in URL.
-  var url = window.location.href;
-  var inx = url.indexOf("#");
-  if (inx !== -1) {
-    var hash = url.substring(inx + 1);
-    $("a[href='#" + hash + "']").click();
-  }
-
   sectionHeight();
+  
+  scrollToHeadingInUrl();
 
   $('img').on('load', sectionHeight);
 });


### PR DESCRIPTION
Fixes issue #7. I'm not sure how clean it feels to do it this way, but essentially we're simulating a click on the appropriate heading listed at the left hand side of the page in the menu, if the URL specifies a heading to scroll to (like this `https://pages-themes.github.io/leap-day/#heading-2`). This has a couple of advantages:
- As far as I know there's no way to do this without JavaScript
- It's decoupled from whichever scrolling framework powers the click event on the left-hand menu

But has a caveat:
- This will only work for headings listed in the left-hand menu (`h1` and `h2`) so `h3-h6` will have the same issue as before (unless we add them to the menu by changing [the selector here](https://github.com/pages-themes/leap-day/blob/441d538a32e0569c966d26be84fc70e025c0f8b5/assets/js/main.js#L16)).

I've tried to stick with the existing coding style.