### PR TITLE
Fix calls to linear-gradient

### DIFF
--- a/_sass/jekyll-theme-leap-day.scss
+++ b/_sass/jekyll-theme-leap-day.scss
@@ -198,7 +198,7 @@ header {
 
   .button {
     border: 1px solid #dba500;
-    background: linear_gradient(rgb(255, 231, 136), rgb(255, 206, 56));
+    background: linear-gradient(rgb(255, 231, 136), rgb(255, 206, 56));
     border-radius: 2px;
     box-shadow: inset 0px 1px 0px rgba(255,255,255,.4), 0px 1px 1px rgba(0,0,0,.1);
     background-color: #FFE788;
@@ -213,7 +213,7 @@ header {
     text-align:center;
 
     &:hover {
-      background: linear_gradient(rgb(255, 231, 136), rgb(255, 231, 136));
+      background: linear-gradient(rgb(255, 231, 136), rgb(255, 231, 136));
       background-color: #ffeca0;
     }
   }


### PR DESCRIPTION
There is a typo in calls to the CSS function `linear-gradient` (currently `linear_gradient` instead). This PR fixes that. Tested on Windows/Chrome Version 66.0.3359.181 (Official Build) (64-bit). Fixes #24.

Here's a little before (top) after (bottom):

![gradient_before_after](https://user-images.githubusercontent.com/5577382/40188429-d2c59560-59f1-11e8-8f66-3def8751bb12.png)
