### PR TITLE
Add way to link to another header in the page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,7 +16,7 @@ $(function() {
   $("section h1, section h2, section h3").each(function(){
     var headerName = $(this).text();
     var headerId = headerName.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'');
-    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + headerId + "'>" + headerName + "</a></li>");
+    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "' id='nav-" + headerId + "'><a href='#" + headerId + "'>" + headerName + "</a></li>");
     $(this).attr("id", headerId);
     $("nav ul li:first-child a").parent().addClass("active");
   });
@@ -26,6 +26,16 @@ $(function() {
     $("html, body").animate({scrollTop: position}, 400);
     $("nav ul li a").parent().removeClass("active");
     $(this).parent().addClass("active");
+    event.preventDefault();
+  });
+
+  $(".jump-to-header").click(function(event) {
+    var position = $($(this).attr("href")).offset().top - 190;
+    $("html, body").animate({scrollTop: position}, 400);
+    $("nav ul li.active").each(function() {
+      $(this).removeClass("active");
+    });
+    $('#nav-' + $(this).attr("href").substring(1)).addClass("active");
     event.preventDefault();
   });
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,8 +14,10 @@ $(window).resize(sectionHeight);
 
 $(function() {
   $("section h1, section h2, section h3").each(function(){
-    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'') + "'>" + $(this).text() + "</a></li>");
-    $(this).attr("id",$(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,''));
+    var headerName = $(this).text();
+    var headerId = headerName.toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'');
+    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + headerId + "'>" + headerName + "</a></li>");
+    $(this).attr("id", headerId);
     $("nav ul li:first-child a").parent().addClass("active");
   });
 

--- a/index.md
+++ b/index.md
@@ -92,6 +92,10 @@ end
   - level 2 item
 - level 1 item
 
+### A link to another header:
+
+This is a [link to header 3](#header-3){:class="jump-to-header"}
+
 ### Small image
 
 ![Octocat](https://assets-cdn.github.com/images/icons/emoji/octocat.png)


### PR DESCRIPTION
This change allows scrolling behavior for links in the main text to another header to work as they already do for nav links. Right now, it requires the developer to add a class to the link element to get this behavior, because I wasn't sure that you'd want it to happen automatically for any link starting with '#' outside of nav.

Added an example of this feature to index.md.

Note that the automated tests do not pass, but they did not pass for me on master. The issue seems to be coming from an 'auto' value for padding, which the W3C validator does not like (I'm guessing that's a new addition to their tests).