### PR TITLE
Changed to Matt Graham's new Twitter handle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@
         {% if site.github.is_project_page %}
           <p>Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
         {% endif %}
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></small></p>
+        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></small></p>
       </footer>
     </div>
 


### PR DESCRIPTION
If one visits the old Twitter handle, they will see that this user has no tweets and the bio says:

> This account has been moved to `@mattgraham` please follow over there.

Therefore the link gets updated to the new handle.