### PR TITLE
Allow each page to have a different title and tagline from Front Matter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,8 +17,8 @@
   <body>
 
       <header>
-        <h1>{{ site.title | default: site.github.repository_name }}</h1>
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
+        <h1>{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+        <p>{{ page.description | default: site.description | default: site.github.project_tagline }}</p>
       </header>
 
       <div id="banner">


### PR DESCRIPTION
This PR enables each page to have their own title and tagline, by specifying `title` and `description` in the Front Matter, like this:

```yaml
---
title: "The special title for this page"
description: "A lovely tagline"
---

Markdown content
```