### PR TITLE
Added styled KBD tag, like in primer theme

### DIFF
--- a/_sass/jekyll-theme-leap-day.scss
+++ b/_sass/jekyll-theme-leap-day.scss
@@ -111,6 +111,20 @@ pre {
   }
 }
 
+kbd {
+  background-color: #fafbfc;
+  border: 1px solid #c6cbd1;
+  border-bottom-color: #959da5;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #959da5;
+  color: #444d56;
+  display: inline-block;
+  font-size: 11px;
+  line-height: 10px;
+  padding: 3px 5px;
+  vertical-align: middle;
+}
+
 table {
   width:100%;
   border-collapse:collapse;


### PR DESCRIPTION
![94258975-679ed200-ff36-11ea-9672-0c65556cd103](https://user-images.githubusercontent.com/13422799/94999371-9285c780-05c1-11eb-8b5b-bdf67d0bbc02.png)

Styles were taken from https://github.com/pages-themes/primer/blob/master/_sass/primer-markdown/lib/markdown-body.scss#L93

P.S. Pull request is similar to pages-themes/slate#47 because I'm adding KBD styles for all pages themes.