### PR TITLE
Use "id" as Refs in Table of Content If Available

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,8 +14,14 @@ $(window).resize(sectionHeight);
 
 $(function() {
   $("section h1, section h2, section h3").each(function(){
-    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'') + "'>" + $(this).text() + "</a></li>");
-    $(this).attr("id",$(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,''));
+    var href = $(this).attr("id");
+
+    if (!href) {
+      href = $(this).text().toLowerCase().replace(/ /g, '-').replace(/[^\w-]+/g,'');
+    }
+
+    $("nav ul").append("<li class='tag-" + this.nodeName.toLowerCase() + "'><a href='#" + href + "'>" + $(this).text() + "</a></li>");
+    $(this).attr("id",href);
     $("nav ul li:first-child a").parent().addClass("active");
   });
 


### PR DESCRIPTION
Implement #49 

When the header already has ids specified, rather than using the header
content as refs in the table of content, use the id. Fallback to using
header content when ids are not available.

**When I checkout from the master branch, script/cibuild is already failing with the following**. I am not sure how to fix it.
```
Offenses:

jekyll-theme-leap-day.gemspec:1:1: C: Gemspec/RequiredRubyVersion: required_ruby_version should be specified.
# frozen_string_literal: true
```