### PR TITLE
Add _sass/leap-day.scss to allow importing with theme name while using jekyll-remote-theme

### DIFF
--- a/_sass/leap-day.scss
+++ b/_sass/leap-day.scss
@@ -1,0 +1,4 @@
+// Placeholder file. If your site uses
+//     @import "{{ site.theme }}";
+// Then using this theme with jekyll-remote-theme will work fine.
+@import "jekyll-theme-leap-day";


### PR DESCRIPTION
Allows use of `@import {{site.theme}}` when you have `remote_theme: pages-theme/leap-day@v0.2.0` in your `_config.yml`.