### PR TITLE
Remove 'auto' from padding since it's not a valid padding

### DIFF
--- a/_sass/jekyll-theme-leap-day.scss
+++ b/_sass/jekyll-theme-leap-day.scss
@@ -406,7 +406,7 @@ footer {
   section {
     border:1px solid #e5e5e5;
     border-width:1px 0;
-    padding:20px auto;
+    padding:20px 0;
     margin: 190px auto 20px;
     max-width: 600px;
   }


### PR DESCRIPTION
cibuild on `master` is returning the following error:

```text
Checking index.html...
Valid!
Checking assets/css/style.css...
ERROR; URI: file://localhost/TextArea; line 311:

                                Value Error :  padding (nullbox.html#propdef-padding)

                                “auto” is not a “padding” value :
```