### PR TITLE
Make the `nav` menu scrollable

### DIFF
--- a/_sass/jekyll-theme-leap-day.scss
+++ b/_sass/jekyll-theme-leap-day.scss
@@ -304,9 +304,11 @@ nav {
   width: 230px;
   position: fixed;
   top: 220px;
-  left:50%;
+  left: 50%;
+  bottom: 0;
   margin-left:-580px;
   text-align: right;
+  overflow-y: auto;
 
   ul {
     list-style: none;


### PR DESCRIPTION
When the `<nav>` menu has many items (is long) or on short-height windows or screens, the `<nav>` simply overflows the window with the overflown items cut-off and inaccessible. This quick-fix proposal constraints the `<nav>` at the `bottom` and enables scrolling for `overflow` behaviour.

Although, browsers’ – at least Chrome – scrollbars look *thicc* and out of place.

I discovered this oversight while trying to fix #48/#62. This can be an initiating step, as the next would be making the `bottom` retract to make room for the `<footer>` (which has non-constant height, and I am not aware of how to respond to that).