### PR TITLE
Set header width to <inherit> instead of <100%>

### DIFF
--- a/_sass/jekyll-theme-leap-day.scss
+++ b/_sass/jekyll-theme-leap-day.scss
@@ -168,7 +168,7 @@ header {
   top: 0;
   left:0;
   right:0;
-  width: 100%;
+  width: inherit;
   text-align: center;
   background: url(../images/background.png) #4276b6;
   box-shadow: 1px 0px 2px rgba(0,0,0,.75);


### PR DESCRIPTION
Setting the header's width to "inherit" will cause the header to have the same width as the body, thus not overlapping the vertical scrollbar. As a result, the header's text will be horizontally centered over the page's section tag.
<img width="1212" alt="Screenshot 2023-12-06 at 4 24 30 PM" src="https://github.com/pages-themes/leap-day/assets/44716415/9039a9fc-573b-471d-bb86-de79f340ced6">
<img width="1213" alt="Screenshot 2023-12-06 at 4 23 54 PM" src="https://github.com/pages-themes/leap-day/assets/44716415/e8a7df9e-4662-4487-bf62-8817bd3d6e18">
