### PR TITLE
Make section scrolling work with modified CSS

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,7 +20,7 @@ $(function() {
   });
 
   $("nav ul li").on("click", "a", function(event) {
-    var position = $($(this).attr("href")).offset().top - 190;
+    var position = $($(this).attr("href")).offset().top - parseInt($('section').css('margin-top'));
     $("html, body").animate({scrollTop: position}, 400);
     $("nav ul li a").parent().removeClass("active");
     $(this).parent().addClass("active");


### PR DESCRIPTION
190px is hardcoded in the Javascript, whereas a user of this theme can easily override the size of the header and banner, and hence the location of the top of the main section. This change makes the scrollTop location when clicking a nav link always be correct, instead of assuming the main section is always 190px from the top.